### PR TITLE
Add TRD pipeline picker

### DIFF
--- a/Clients/TRD/Pipelines/RB.json
+++ b/Clients/TRD/Pipelines/RB.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RB",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}

--- a/Clients/TRD/Pipelines/RHNGL.json
+++ b/Clients/TRD/Pipelines/RHNGL.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RHNGL",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}

--- a/Clients/TRD/Pipelines/RRDEI.json
+++ b/Clients/TRD/Pipelines/RRDEI.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RRDEI",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}

--- a/Clients/TRD/Pipelines/RRGPX.json
+++ b/Clients/TRD/Pipelines/RRGPX.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RRGPX",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}

--- a/Clients/TRD/Pipelines/RRR.json
+++ b/Clients/TRD/Pipelines/RRR.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RRR",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}

--- a/Clients/TRD/Pipelines/RRTW.json
+++ b/Clients/TRD/Pipelines/RRTW.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RRTW",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}

--- a/Clients/TRD/Pipelines/RT.json
+++ b/Clients/TRD/Pipelines/RT.json
@@ -1,0 +1,29 @@
+{
+  "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
+  "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
+  "report_prefix": "TargaND_RT",
+  "placeholders": {
+    "pipeline": {
+      "{{ PLACEHOLDER_DATE_TIME }}": "",
+      "{{ FILE_NAME }}": "",
+      "{{ LATITUDE }}": "",
+      "{{ LONGITUDE }}": "",
+      "{{ GOOGLE_URL }}": "",
+      "{{ PILOT_NOTES }}": ""
+    },
+    "summary": {
+      "{{ PIPELINE_ID }}": "",
+      "{{ Photo_ID }}": "",
+      "{{ LAT_LONG }}": "",
+      "{{ CODE }}": "",
+      "{{ STATUS }}": "",
+      "{{ NOTE_FIELD }}": ""
+    }
+  },
+  "image_box": [
+    49.64,
+    78.52,
+    576.64,
+    375.35
+  ]
+}


### PR DESCRIPTION
## Summary
- add a list of TRD pipeline names for the GUI
- show a pipeline selector when the TRD client is chosen
- pass the chosen pipeline through to the report generator
- load optional pipeline-specific config files
- create individual configs for each TRD pipeline

## Testing
- `python -m py_compile report_generator.py custom_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_68827b49b7188333b7fa926d6a29046b