### PR TITLE
Add TRD pipeline picker

### DIFF
--- a/Clients/TRD/Pipelines/RB.json
+++ b/Clients/TRD/Pipelines/RB.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RB",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/Clients/TRD/Pipelines/RHNGL.json
+++ b/Clients/TRD/Pipelines/RHNGL.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RHNGL",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/Clients/TRD/Pipelines/RRDEI.json
+++ b/Clients/TRD/Pipelines/RRDEI.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RRDEI",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/Clients/TRD/Pipelines/RRGPX.json
+++ b/Clients/TRD/Pipelines/RRGPX.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RRGPX",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/Clients/TRD/Pipelines/RRR.json
+++ b/Clients/TRD/Pipelines/RRR.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RRR",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/Clients/TRD/Pipelines/RRTW.json
+++ b/Clients/TRD/Pipelines/RRTW.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RRTW",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/Clients/TRD/Pipelines/RT.json
+++ b/Clients/TRD/Pipelines/RT.json
@@ -1,7 +1,7 @@
 {
   "template_pipeline": "Clients/TRD/Templates - DOCX/TargaDelaware_PipelineReportTemplate.docx",
   "template_summary": "Clients/TRD/Templates - DOCX/TargaDelaware_Summary_Template.docx",
-  "report_prefix": "TargaResources-ND",
+  "report_prefix": "TargaResources-ND_RT",
   "placeholders": {
     "pipeline": {
       "{{ PLACEHOLDER_DATE_TIME }}": "",

--- a/custom_ui.py
+++ b/custom_ui.py
@@ -6,6 +6,16 @@ import sys
 import threading
 import queue
 from report_generator import OUTPUT_FOLDER_NAME
+
+TRD_PIPELINES = {
+    "RHNGL": "Red Hills NGL",
+    "RRGPX": "RR GPX Lateral - 2",
+    "RRR": "Road Runner Residue",
+    "RRTW": "Road Runner TW",
+    "RT": "Rojo Toro",
+    "RB": "Rojo Banco",
+    "RRDEI": "RR Double E Int",
+}
 from PIL import Image
 from pathlib import Path
 
@@ -101,6 +111,18 @@ class ReportGUI(ctk.CTk):
                                              command=self.update_cover_dir)
         self.client_menu.pack(side="left", fill="x", expand=True, padx=(10, 0))
 
+        # Pipeline Selection for TRD
+        self.pipeline_frame = ctk.CTkFrame(settings_card, fg_color="transparent")
+        pipeline_label = ctk.CTkLabel(self.pipeline_frame, text="Select Pipeline:", width=150, anchor="w")
+        pipeline_label.pack(side="left")
+        self.pipeline_var = ctk.StringVar()
+        pipeline_values = [f"{k} - {v}" for k, v in TRD_PIPELINES.items()]
+        self.pipeline_menu = ctk.CTkOptionMenu(self.pipeline_frame, variable=self.pipeline_var, values=pipeline_values)
+        if pipeline_values:
+            self.pipeline_var.set(pipeline_values[0])
+        self.pipeline_menu.pack(side="left", fill="x", expand=True, padx=(10, 0))
+        self.pipeline_frame.pack_forget()
+
         # Cover Photo
         cover_frame = ctk.CTkFrame(settings_card, fg_color="transparent")
         cover_frame.pack(fill="x", padx=20, pady=10)
@@ -128,6 +150,9 @@ class ReportGUI(ctk.CTk):
         self.view_button.pack(pady=10)
         self.view_button.pack_forget()
 
+        # Ensure pipeline frame visibility based on initial client
+        self.update_cover_dir()
+
         # Bind resize event for logo
         self.bind("<Configure>", self._on_resize)
 
@@ -138,6 +163,10 @@ class ReportGUI(ctk.CTk):
 
     def update_cover_dir(self, *_):
         self.cover_var.set("")
+        if self.client_var.get() == "TRD":
+            self.pipeline_frame.pack(fill="x", padx=20, pady=10)
+        else:
+            self.pipeline_frame.pack_forget()
 
     def browse_cover(self):
         client = self.client_var.get()
@@ -160,6 +189,10 @@ class ReportGUI(ctk.CTk):
     def _on_generate(self):
         folder = self.path_var.get()
         client = self.client_var.get()
+        pipeline = None
+        if client == "TRD":
+            selection = self.pipeline_var.get()
+            pipeline = selection.split(" - ")[0] if selection else None
         cover = self.cover_var.get() or None
         pilots = self._collect_pilots()
         if not folder:
@@ -174,12 +207,12 @@ class ReportGUI(ctk.CTk):
         self.gen_btn.configure(state="disabled")
         self.update()
 
-        thread = threading.Thread(target=self._generate_thread, args=(folder, client, cover, pilots))
+        thread = threading.Thread(target=self._generate_thread, args=(folder, client, pipeline, cover, pilots))
         thread.start()
         self._check_queue()
 
-    def _generate_thread(self, folder, client, cover, pilots):
-        self.generate_callback(folder, client, cover, pilots, self._queue_progress, self._queue_status)
+    def _generate_thread(self, folder, client, pipeline, cover, pilots):
+        self.generate_callback(folder, client, pipeline, cover, pilots, self._queue_progress, self._queue_status)
 
     def _queue_progress(self, value):
         self.progress_queue.put(("progress", value))


### PR DESCRIPTION
## Summary
- add a list of TRD pipeline names for the GUI
- show a pipeline selector when the TRD client is chosen
- pass the chosen pipeline through to the report generator
- load optional pipeline-specific config files
- create individual configs for each TRD pipeline
- update TRD report prefixes to use `TargaResources-ND`
- fix initialization order for the pipeline selector

## Testing
- `python -m py_compile report_generator.py custom_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68827b49b7188333b7fa926d6a29046b