### PR TITLE
Fix GUI init regression

### DIFF
--- a/custom_ui.py
+++ b/custom_ui.py
@@ -121,11 +121,8 @@ class ReportGUI(ctk.CTk):
         if pipeline_values:
             self.pipeline_var.set(pipeline_values[0])
         self.pipeline_menu.pack(side="left", fill="x", expand=True, padx=(10, 0))
+
         self.pipeline_frame.pack_forget()
-
-
-        # Ensure pipeline frame visibility based on initial client
-        self.update_cover_dir()
 
 
         # Cover Photo


### PR DESCRIPTION
## Summary
- avoid calling `update_cover_dir` before `cover_var` exists

## Testing
- `python -m py_compile custom_ui.py report_generator.py docs/split_clients.py`
- `python docs/split_clients.py` *(fails: clients.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688284c697588333b4139ad6f8255c95